### PR TITLE
[MsC-204][REF] SO, PO, MO, Pickings cancellation when the SO is cancelled

### DIFF
--- a/mc_mrp/models/product_attribute_custom_value.py
+++ b/mc_mrp/models/product_attribute_custom_value.py
@@ -7,6 +7,8 @@ from odoo import fields, models
 class ProductAttributeCustomValue(models.Model):
     _inherit = 'product.attribute.custom.value'
 
+    sale_order_line_id = fields.Many2one('sale.order.line', copy=False) # Add copy False to standard field
+
     def unlink(self):
         """
         Allow to delete custom value link to a purchase order line

--- a/mc_mrp/models/purchase_order.py
+++ b/mc_mrp/models/purchase_order.py
@@ -46,10 +46,11 @@ class PurchaseOrder(models.Model):
         """
         res = super(PurchaseOrder, self)._prepare_sale_order_line_data(line, company, sale_id)
         if line.product_no_variant_attribute_value_ids or line.product_custom_attribute_value_ids:
+            product_custom_attribute_values = line.product_custom_attribute_value_ids.copy_data()
             res.update({
                 'name': line.name,
                 'product_no_variant_attribute_value_ids': [(6, 0, line.product_no_variant_attribute_value_ids.ids)],
-                'product_custom_attribute_value_ids': [(6, 0, line.product_custom_attribute_value_ids.ids)],
+                'product_custom_attribute_value_ids': [(0, 0, pcav) for pcav in product_custom_attribute_values],
                 'comment': line.comment,
             })
         res['trigger_product_id_onchange'] = True # Used to trigger the product_id_onchange in the create method!

--- a/mc_mrp/models/sale_order.py
+++ b/mc_mrp/models/sale_order.py
@@ -143,3 +143,23 @@ class SaleOrder(models.Model):
             if external_sales_lot:
                 external_sales_lot.write({'external_state': 'in_manufacturing'})
             purchase_order_id.button_confirm()
+
+    def action_cancel(self):
+        """
+        Overridden method
+        Cancel the SO, PO, MO and pickings linked to the sales_lot_id
+        """
+        for order in self:
+            sales_lot_ids = order.order_line.mapped('sales_lot_id')
+            if sales_lot_ids:
+                sales_lot_manuf_order = sales_lot_ids.sudo().mapped('production_ids')
+                for mo in sales_lot_manuf_order:
+                    if mo.state == 'done':
+                        raise UserError(_('The MO {} is already done, so you cannot cancel it!').format(mo.name))
+                    elif sum(mo.move_raw_ids.mapped('reserved_availability')) > 0 or sum(mo.move_raw_ids.mapped('quantity_done')) > 0:
+                        raise UserError(_('The MO {} has already some Reserved or Consumed quantity in its components!').format(mo.name))
+                sales_lot_ids.mapped('purchase_order_ids').filtered(lambda po: po.state != 'cancel').button_cancel()
+                sales_lot_ids.mapped('production_ids').filtered(lambda morder: morder.state != 'cancel').action_cancel()
+                sales_lot_ids.mapped('picking_ids').filtered(lambda pick: pick.state != 'cancel').action_cancel()
+        res = super(SaleOrder, (self.order_line.mapped('sales_lot_id.sale_order_ids').filtered(lambda so: so.state != 'cancel'))).action_cancel()
+        return res

--- a/mc_mrp/models/sale_order.py
+++ b/mc_mrp/models/sale_order.py
@@ -121,10 +121,11 @@ class SaleOrder(models.Model):
             if purchase_order_lines:
                 purchase_order_ids |= purchase_order_lines.mapped('order_id')
             if line.move_ids:
-                move = line.move_ids[0]
-                purchase_order_line = move._get_purchase_line_id()
-                if purchase_order_line:
-                    purchase_order_ids |= purchase_order_line.order_id
+                move = line.move_ids.filtered(lambda m: m.state != 'cancel')[0] if line.move_ids.filtered(lambda m: m.state != 'cancel') else False
+                if move:
+                    purchase_order_line = move._get_purchase_line_id()
+                    if purchase_order_line:
+                        purchase_order_ids |= purchase_order_line.order_id
         return purchase_order_ids
 
     def action_confirm_purchase_order(self):

--- a/mc_sale/models/sale_order.py
+++ b/mc_sale/models/sale_order.py
@@ -82,13 +82,21 @@ class SaleOrder(models.Model):
     def action_cancel(self):
         """
         Overridden method
-        Cancel the PO linked.
+        Cancel the SO, PO, MO and pickings linked to the sales_lot_id
         """
-        for rec in self:
-            po_id = rec._get_purchase_order()
-            if po_id:
-                po_id.button_cancel()
-        res = super(SaleOrder, self).action_cancel()
+        for order in self:
+            sales_lot_ids = order.order_line.mapped('sales_lot_id')
+            if sales_lot_ids:
+                sales_lot_manuf_order = sales_lot_ids.sudo().mapped('production_ids')
+                for mo in sales_lot_manuf_order:
+                    if mo.state == 'done':
+                        raise UserError(_('The MO {} is already done, so you cannot cancel it!').format(mo.name))
+                    elif sum(mo.move_raw_ids.mapped('reserved_availability')) > 0 or sum(mo.move_raw_ids.mapped('quantity_done')) > 0:
+                        raise UserError(_('The MO {} has already some Reserved or Consumed quantity in its components!').format(mo.name))
+                sales_lot_ids.mapped('purchase_order_ids').filtered(lambda po: po.state != 'cancel').button_cancel()
+                sales_lot_ids.mapped('production_ids').filtered(lambda morder: morder.state != 'cancel').action_cancel()
+                sales_lot_ids.mapped('picking_ids').filtered(lambda pick: pick.state != 'cancel').action_cancel()
+        res = super(SaleOrder, (self.order_line.mapped('sales_lot_id.sale_order_ids').filtered(lambda so: so.state != 'cancel'))).action_cancel()
         return res
 
     def action_compute_pricelist_discount(self):


### PR DESCRIPTION
Dev par RRA
Vérifier si des lignes du SO ont des numéro de production (so_lines.mapped('sales_lot_id')) si oui passer au point 2.

Reprendre tous les MO liés au num de prod (so_lines.mapped('sales_lot_id.production_ids') attention ils appartiennent à une autre compagnie sudo()), vérifier qu'aucun des MO n'est dans le status 'done' si c'est le cas renvoyer un message d'erreur bloquant spécifiant les nom des MO qui bloque l'annulation, bloquer aussi si réservation ou consomation encodéé sur le MO.

Si le point 2 n'a pas renvoyé de message d'erreur annulé tous les SO, PO, MO, Picking liés au numéro de production. so_lines.mapped('sales_lot_id.sale_order_ids'), so_lines.mapped('sales_lot_id.purchase_order_ids'), so_lines.mapped('sales_lot_id.production_ids'), so_lines.mapped('sales_lot_id.picking_ids'). Attention que le processus doit pouvoir être fait plusieurs fois! 1. Annuler un SO MC -> 2. le confirmer -> 3. Envoyer en production -> 4. Annuler le SO -> 5. Remettre en brouillon -> 6. Modifier une ligne du SO -> repasser un point 2