### PR TITLE
[MsC-223][ADD] PDF SO pas reprendre les lignes avec qty zéro + traductions

### DIFF
--- a/mc_sale/i18n/de.po
+++ b/mc_sale/i18n/de.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-08 07:38+0000\n"
-"PO-Revision-Date: 2021-03-08 08:49+0100\n"
+"POT-Creation-Date: 2021-05-06 09:49+0000\n"
+"PO-Revision-Date: 2021-05-06 12:01+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
 "Language: de\n"
-"X-Generator: Poedit 2.4.2\n"
+"X-Generator: Poedit 2.4.3\n"
 
 #. module: mc_sale
 #: model_terms:ir.ui.view,arch_db:mc_sale.contact_name
@@ -28,8 +28,22 @@ msgid "('Contact Sticker - %s' % (object.name))"
 msgstr ""
 
 #. module: mc_sale
-#: model_terms:ir.ui.view,arch_db:mc_sale.contact_name
-msgid ",&amp;nbsp;"
+#: model:mail.template,body_html:mc_sale.mail_template_send_mail_confirmation_order
+msgid ""
+"<?xml version=\"1.0\"?>\n"
+"<div style=\"margin: 0px; padding: 0px;\">\n"
+"                    <p style=\"margin: 0px; padding: 0px;font-size: 13px;"
+"\">\n"
+"                        Hello,\n"
+"                        <br/>\n"
+"                        <br/>\n"
+"                        Thanks to prepare this command : ${object.name}\n"
+"                        <br/>\n"
+"                        <br/>\n"
+"                        Thank you,\n"
+"                    </p>\n"
+"                </div>\n"
+"            "
 msgstr ""
 
 #. module: mc_sale
@@ -65,6 +79,18 @@ msgid ""
 msgstr ""
 "Wird automatisch mit der ersten verfügbaren Versandart für die aktuelle "
 "Lieferadresse gefüllt."
+
+#. module: mc_sale
+#. openerp-web
+#: code:addons/mc_sale/static/src/js/product_configurator_controller.js:0
+#, python-format
+msgid "Back"
+msgstr "Zurück"
+
+#. module: mc_sale
+#: model:ir.model.fields,field_description:mc_sale.field_stock_picking__carrier_id
+msgid "Carrier"
+msgstr "Frachtführer"
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_sale_order__comment
@@ -107,6 +133,20 @@ msgstr ""
 "Bestellungen angezeigt wird."
 
 #. module: mc_sale
+#. openerp-web
+#: code:addons/mc_sale/static/src/js/product_configurator_controller.js:0
+#, python-format
+msgid "Configure"
+msgstr "Konfigurieren"
+
+#. module: mc_sale
+#. openerp-web
+#: code:addons/mc_sale/static/src/js/product_configurator_controller.js:0
+#, python-format
+msgid "Confirm"
+msgstr "Bestätigen"
+
+#. module: mc_sale
 #: model:ir.actions.report,name:mc_sale.action_report_partner_sticker
 msgid "Contact Sticker (ZPL)"
 msgstr ""
@@ -135,10 +175,9 @@ msgstr ""
 "Bestätigungsdatum von Aufträgen."
 
 #. module: mc_sale
-#: model:ir.model.fields,field_description:mc_sale.field_sale_order_line__price_unit
-#: model_terms:ir.ui.view,arch_db:mc_sale.sale_order_form_view
-msgid "Customer Price"
-msgstr "Kundenpreis"
+#: model:ir.model.fields,help:mc_sale.field_sale_order__registered_date_order
+msgid "Date of the very first confirmation of current sale order."
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute__default_linear_value
@@ -157,7 +196,6 @@ msgstr ""
 
 #. module: mc_sale
 #: model_terms:ir.ui.view,arch_db:mc_sale.view_order_tree
-#: model_terms:ir.ui.view,arch_db:mc_sale.view_quotation_tree
 #: model_terms:ir.ui.view,arch_db:mc_sale.view_sales_order_filter
 msgid "Delivery Date"
 msgstr ""
@@ -206,7 +244,7 @@ msgstr ""
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_res_company__eori
 msgid "EORI"
-msgstr "EORI"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_res_company__eori_uk
@@ -221,7 +259,12 @@ msgstr "EORI Großbritannien:"
 #. module: mc_sale
 #: model_terms:ir.ui.view,arch_db:mc_sale.external_layout_boxed
 msgid "EORI:"
-msgstr "EORI:"
+msgstr ""
+
+#. module: mc_sale
+#: model_terms:ir.ui.view,arch_db:mc_sale.view_quotation_tree
+msgid "Effective Date"
+msgstr ""
 
 #. module: mc_sale
 #: model_terms:ir.ui.view,arch_db:mc_sale.contact
@@ -271,11 +314,16 @@ msgid "Fix Amount"
 msgstr "Fixbetrag"
 
 #. module: mc_sale
+#: model:ir.model.fields,field_description:mc_sale.field_product_product__hs_code
+msgid "HS Code"
+msgstr "HS-Code"
+
+#. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute_value_percentage_price__id
 #: model:ir.model.fields,field_description:mc_sale.field_product_configurator_description_line__id
 #: model:ir.model.fields,field_description:mc_sale.field_product_configurator_description_line_value__id
 msgid "ID"
-msgstr "ID"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,help:mc_sale.field_product_attribute_value__is_none_value
@@ -411,6 +459,11 @@ msgid "Order Date"
 msgstr "Bestelldatum"
 
 #. module: mc_sale
+#: model:mail.template,subject:mc_sale.mail_template_send_mail_confirmation_order
+msgid "Order confirmation (Ref ${object.name})"
+msgstr ""
+
+#. module: mc_sale
 #: model:ir.model.fields.selection,name:mc_sale.selection__product_attribute_value_percentage_price__type__percentage
 msgid "Percentage"
 msgstr "Prozent"
@@ -475,9 +528,10 @@ msgid "Product Attribute Value"
 msgstr "Produkt-Attribut Wert"
 
 #. module: mc_sale
+#: model:ir.model,name:mc_sale.model_product_category
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute_value_percentage_price__product_category_id
 msgid "Product Category"
-msgstr "Produkt-Kategorie"
+msgstr "Produktkategorie"
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_sale_product_configurator__product_cost
@@ -493,6 +547,11 @@ msgstr "Produktvorlage"
 #: model:ir.model,name:mc_sale.model_product_template_attribute_value
 msgid "Product Template Attribute Value"
 msgstr "Produktvorlage Attributwert"
+
+#. module: mc_sale
+#: model:ir.model.fields,field_description:mc_sale.field_product_product__product_variant_seller_ids
+msgid "Product Vendors"
+msgstr ""
 
 #. module: mc_sale
 #: code:addons/mc_sale/models/product_attribute_value_percentage_price.py:0
@@ -525,9 +584,30 @@ msgid "Quantity of fabric required to upholster furniture"
 msgstr "Menge des zum Polstern von Möbeln benötigten Stoffes"
 
 #. module: mc_sale
+#: model_terms:ir.ui.view,arch_db:mc_sale.view_quotation_tree
+msgid "Quotation Date"
+msgstr ""
+
+#. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_purchase_order__date_planned
 msgid "Receipt Date"
 msgstr "Lieferdatum"
+
+#. module: mc_sale
+#: model_terms:ir.ui.view,arch_db:mc_sale.sale_order_form_view
+msgid "Recompute Pricelist Discounts"
+msgstr ""
+
+#. module: mc_sale
+#: model:ir.model.fields,field_description:mc_sale.field_sale_order__registered_date_order
+msgid "Registered Order Date"
+msgstr ""
+
+#. module: mc_sale
+#: model:ir.model.fields,field_description:mc_sale.field_delivery_carrier__route_id
+#: model:ir.model.fields,field_description:mc_sale.field_sale_order_line__route_id
+msgid "Route"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_sale_product_configurator
@@ -550,9 +630,34 @@ msgid "Sales Order Line"
 msgstr "Kundenauftragszeile"
 
 #. module: mc_sale
+#: model:ir.model.fields,field_description:mc_sale.field_stock_picking__scheduled_date
+msgid "Scheduled Date"
+msgstr "Geplantes Datum"
+
+#. module: mc_sale
+#: model:ir.model.fields,help:mc_sale.field_stock_picking__scheduled_date
+msgid ""
+"Scheduled time for the first part of the shipment to be processed. Setting "
+"manually a value here would set it as expected date for all the stock moves."
+msgstr ""
+"Geplantes Datum für die Auslieferung der ersten Lieferpositionen. Ein "
+"manueller Eintrag überträgt dieses Datum auch auf alle anderen "
+"Lieferpositionen."
+
+#. module: mc_sale
+#: model:ir.model.fields,field_description:mc_sale.field_product_category__send_mail_order_confirmation
+msgid "Send order confirmation mail"
+msgstr ""
+
+#. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_configurator_description_line__sequence
 msgid "Sequence"
 msgstr "Reihenfolge"
+
+#. module: mc_sale
+#: model:ir.model,name:mc_sale.model_delivery_carrier
+msgid "Shipping Methods"
+msgstr "Versandmethoden"
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_account_move_line__short_name
@@ -577,6 +682,15 @@ msgid "Standard Sale Price"
 msgstr "Standard-Verkaufspreis"
 
 #. module: mc_sale
+#: model:ir.model.fields,help:mc_sale.field_product_product__hs_code
+msgid ""
+"Standardized code for international shipping and goods declaration. At the "
+"moment, only used for the FedEx shipping provider."
+msgstr ""
+"Standardisierter Code für den internationalen Versand und die "
+"Warendeklaration. Im Moment nur für den FedEx-Versand verwendet."
+
+#. module: mc_sale
 #: model:ir.model,name:mc_sale.model_stock_move
 msgid "Stock Move"
 msgstr "Lagerbuchung"
@@ -595,10 +709,11 @@ msgstr ""
 #. module: mc_sale
 #: model:ir.model.fields.selection,name:mc_sale.selection__product_configurator_description_line_value__type__text
 msgid "Text"
-msgstr "Text"
+msgstr ""
 
 #. module: mc_sale
 #: code:addons/mc_sale/models/product_attribute_custom_value.py:0
+#: code:addons/mc_sale/models/product_template.py:0
 #, python-format
 msgid ""
 "The custom value for the attribute '{}' should be a float like 2.25 or 2,25 "
@@ -615,6 +730,16 @@ msgid ""
 msgstr ""
 "Diese Information wird nach der Produktkonfiguration in der "
 "Kurzbeschreibung einer Verkaufs- oder Bestellzeile sichtbar sein"
+
+#. module: mc_sale
+#: model:ir.model.fields,field_description:mc_sale.field_stock_picking__carrier_tracking_ref
+msgid "Tracking Reference"
+msgstr "Tracking-Referenz"
+
+#. module: mc_sale
+#: model:ir.model,name:mc_sale.model_stock_picking
+msgid "Transfer"
+msgstr "Lieferung vornehmen"
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute_value_percentage_price__type
@@ -654,9 +779,25 @@ msgid "Values"
 msgstr "Werte"
 
 #. module: mc_sale
+#: model_terms:ir.ui.view,arch_db:mc_sale.product_product_easy_edit_form_view
+msgid "Vendors"
+msgstr ""
+
+#. module: mc_sale
+#: model:ir.model.fields,help:mc_sale.field_product_product__product_variant_seller_ids
+msgid "Vendors of current variant."
+msgstr ""
+
+#. module: mc_sale
 #: model_terms:ir.ui.view,arch_db:mc_sale.contact
 msgid "Website"
 msgstr ""
+
+#. module: mc_sale
+#: model:ir.model.fields,field_description:mc_sale.field_sale_order_line__price_unit
+#: model_terms:ir.ui.view,arch_db:mc_sale.sale_order_form_view
+msgid "Your Price"
+msgstr "Ihr Preis"
 
 #. module: mc_sale
 #: model_terms:ir.ui.view,arch_db:mc_sale.product_template_attribute_value_view_form

--- a/mc_sale/i18n/nl_BE.po
+++ b/mc_sale/i18n/nl_BE.po
@@ -6,15 +6,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-06 09:48+0000\n"
-"PO-Revision-Date: 2021-05-06 12:00+0200\n"
+"POT-Creation-Date: 2021-05-06 09:49+0000\n"
+"PO-Revision-Date: 2021-05-06 12:01+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
-"Language: fr_BE\n"
+"Language: nl_BE\n"
 "X-Generator: Poedit 2.4.3\n"
 
 #. module: mc_sale
@@ -45,22 +45,6 @@ msgid ""
 "                </div>\n"
 "            "
 msgstr ""
-"<!--?xml version=\"1.0\"?-->\n"
-"<div style=\"font-size:13px;font-family:&quot;Lucida Grande&quot;, "
-"Helvetica, Verdana, Arial, sans-serif;margin:0px;padding: 0px;\">\n"
-"                    <p style=\"margin:0px;font-family:&quot;Lucida "
-"Grande&quot;, Helvetica, Verdana, Arial, sans-serif;padding: 0px;font-size: "
-"13px;\">\n"
-"                        Bonjour,\n"
-"                        <br>\n"
-"                        <br>\n"
-"                        Merci de préparer cette commande : ${object.name}\n"
-"                        <br>\n"
-"                        <br>\n"
-"                        Merci,\n"
-"                    </p>\n"
-"                </div>\n"
-"            "
 
 #. module: mc_sale
 #: model_terms:ir.ui.view,arch_db:mc_sale.res_config_settings_view_form
@@ -85,7 +69,7 @@ msgstr ""
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_product_attribute_value
 msgid "Attribute Value"
-msgstr "Valeur de la caractéristique"
+msgstr "Kenmerkwaarde"
 
 #. module: mc_sale
 #: model:ir.model.fields,help:mc_sale.field_sale_order__carrier_id
@@ -99,12 +83,12 @@ msgstr ""
 #: code:addons/mc_sale/static/src/js/product_configurator_controller.js:0
 #, python-format
 msgid "Back"
-msgstr "Retour"
+msgstr "Terug"
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_stock_picking__carrier_id
 msgid "Carrier"
-msgstr "Transporteur"
+msgstr "Vervoerder"
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_sale_order__comment
@@ -112,12 +96,12 @@ msgstr "Transporteur"
 #: model:ir.model.fields,field_description:mc_sale.field_sale_product_configurator__comment
 #: model_terms:ir.ui.view,arch_db:mc_sale.sale_order_form_view
 msgid "Comment"
-msgstr "Commentaire"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_res_company
 msgid "Companies"
-msgstr "Sociétés"
+msgstr "Bedrijven"
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute_value_percentage_price__company_id
@@ -127,12 +111,12 @@ msgstr ""
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_res_config_settings
 msgid "Config Settings"
-msgstr "Paramètres de config"
+msgstr "Configuratie instellingen"
 
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_product_configurator_description_line
 msgid "Configuration of Product Description"
-msgstr "Configuration de la description du produit"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,help:mc_sale.field_product_product__description_line_ids
@@ -142,22 +126,20 @@ msgid ""
 "description of product displayed on sale orders lines and purchase orders "
 "lines."
 msgstr ""
-"Configuration de la description courte du produit. Aide à configurer la "
-"courte description du produit affichée sur les lignes des bons de commande."
 
 #. module: mc_sale
 #. openerp-web
 #: code:addons/mc_sale/static/src/js/product_configurator_controller.js:0
 #, python-format
 msgid "Configure"
-msgstr "Configurer"
+msgstr "Configureren"
 
 #. module: mc_sale
 #. openerp-web
 #: code:addons/mc_sale/static/src/js/product_configurator_controller.js:0
 #, python-format
 msgid "Confirm"
-msgstr "Confirmer"
+msgstr "Bevestigen"
 
 #. module: mc_sale
 #: model:ir.actions.report,name:mc_sale.action_report_partner_sticker
@@ -169,14 +151,14 @@ msgstr ""
 #: model:ir.model.fields,field_description:mc_sale.field_product_configurator_description_line__create_uid
 #: model:ir.model.fields,field_description:mc_sale.field_product_configurator_description_line_value__create_uid
 msgid "Created by"
-msgstr "Créé par"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute_value_percentage_price__create_date
 #: model:ir.model.fields,field_description:mc_sale.field_product_configurator_description_line__create_date
 #: model:ir.model.fields,field_description:mc_sale.field_product_configurator_description_line_value__create_date
 msgid "Created on"
-msgstr "Créé le"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,help:mc_sale.field_sale_order__date_order
@@ -184,8 +166,8 @@ msgid ""
 "Creation date of draft/sent orders,\n"
 "Confirmation date of confirmed orders."
 msgstr ""
-"Date de création des ordres d'ébauche/envoyés,\n"
-"Date de confirmation des commandes confirmées."
+"Aanmaakdatum van offertes/verstuurde offertes,\n"
+"Bevestigingsdatum van bevestigde orders"
 
 #. module: mc_sale
 #: model:ir.model.fields,help:mc_sale.field_sale_order__registered_date_order
@@ -195,7 +177,7 @@ msgstr ""
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute__default_linear_value
 msgid "Default Linear Value"
-msgstr "Valeur linéaire par défaut"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,help:mc_sale.field_res_config_settings__fabric_default_product_id
@@ -216,7 +198,7 @@ msgstr ""
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_sale_order__carrier_id
 msgid "Delivery Method"
-msgstr "Méthode de livraison"
+msgstr "Leveringsmethode"
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_configurator_description_line_value__text
@@ -227,26 +209,26 @@ msgstr ""
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_configurator_description_line_value__description_line_id
 msgid "Description Line"
-msgstr "Ligne descriptive"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_product__description_line_ids
 #: model:ir.model.fields,field_description:mc_sale.field_product_template__description_line_ids
 #: model_terms:ir.ui.view,arch_db:mc_sale.product_template_form_view
 msgid "Description Lines"
-msgstr "Lignes descriptives"
+msgstr ""
 
 #. module: mc_sale
 #: model_terms:ir.ui.view,arch_db:mc_sale.product_template_form_view
 msgid "Description Values"
-msgstr "Valeurs de description"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute_value_percentage_price__display_name
 #: model:ir.model.fields,field_description:mc_sale.field_product_configurator_description_line__display_name
 #: model:ir.model.fields,field_description:mc_sale.field_product_configurator_description_line_value__display_name
 msgid "Display Name"
-msgstr "Nom affiché"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_sale_order__down_payment_paid
@@ -287,15 +269,13 @@ msgstr ""
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute_value_percentage_price__price_extra
 msgid "Extra Price"
-msgstr "Prix extra"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_product_attribute_value_percentage_price
 msgid ""
 "Extra Price of an Attribute Value Based on a Percentage of Product Price"
 msgstr ""
-"Prix extra d'une valeur d'attribut basé sur un pourcentage du prix public "
-"du produit"
 
 #. module: mc_sale
 #: model:ir.model.fields,help:mc_sale.field_product_template_attribute_value__price_extra
@@ -303,8 +283,8 @@ msgid ""
 "Extra price for the variant with this attribute value on sale price. eg. "
 "200 price extra, 1000 + 200 = 1200."
 msgstr ""
-"Prix supplémentaire pour la variante avec cette valeur d'attribut sur le "
-"prix de vente. par exemple. 200 prix supplémentaire, 1000 + 200 = 1200."
+"Extra prijs: Extra prijs voor de variant met deze kenmerk waarde, bovenop "
+"de verkoopprijs. Bijvoorbeeld: 200 extra prijs. 1000 + 200 = 1200."
 
 #. module: mc_sale
 #: model_terms:ir.ui.view,arch_db:mc_sale.res_config_settings_view_form
@@ -324,12 +304,12 @@ msgstr ""
 #. module: mc_sale
 #: model:ir.model.fields.selection,name:mc_sale.selection__product_attribute_value_percentage_price__type__amount
 msgid "Fix Amount"
-msgstr "Montant fixe"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_product__hs_code
 msgid "HS Code"
-msgstr "Nomenclature douanière"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute_value_percentage_price__id
@@ -355,7 +335,7 @@ msgstr ""
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute_value__is_none_value
 msgid "Is None Value"
-msgstr "Valeur nulle"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute_value__is_tcl_value
@@ -367,7 +347,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:mc_sale.field_product_template__tailor_made
 #: model:ir.model.fields,field_description:mc_sale.field_sale_product_configurator__product_is_tailor_made
 msgid "Is Tailor Made"
-msgstr "Sur mesure"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute_value__is_to_be_defined_value
@@ -382,79 +362,78 @@ msgstr ""
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_account_move
 msgid "Journal Entries"
-msgstr "Pièces comptables"
+msgstr "Boekingen"
 
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_account_move_line
 msgid "Journal Item"
-msgstr "Écriture comptable"
+msgstr "Boeking"
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute_value_percentage_price____last_update
 #: model:ir.model.fields,field_description:mc_sale.field_product_configurator_description_line____last_update
 #: model:ir.model.fields,field_description:mc_sale.field_product_configurator_description_line_value____last_update
 msgid "Last Modified on"
-msgstr "Dernière modification le"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute_value_percentage_price__write_uid
 #: model:ir.model.fields,field_description:mc_sale.field_product_configurator_description_line__write_uid
 #: model:ir.model.fields,field_description:mc_sale.field_product_configurator_description_line_value__write_uid
 msgid "Last Updated by"
-msgstr "Dernière mise-à-jour par"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute_value_percentage_price__write_date
 #: model:ir.model.fields,field_description:mc_sale.field_product_configurator_description_line__write_date
 #: model:ir.model.fields,field_description:mc_sale.field_product_configurator_description_line_value__write_date
 msgid "Last Updated on"
-msgstr "Dernière mise-à-jour le"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_product__length_uom_name
 #: model:ir.model.fields,field_description:mc_sale.field_product_template__length_uom_name
 msgid "Length UoM Label"
-msgstr "Label UdM de longueur"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute_value__length_uom_name
 msgid "Length UoM Name"
-msgstr "Nom UdM de longueur"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_product__linear_length
 #: model:ir.model.fields,field_description:mc_sale.field_product_template__linear_length
 msgid "Linear Length"
-msgstr "Mètre linéaire"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute__has_linear_price
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute_value__has_linear_price
 msgid "Linear Price"
-msgstr "Prix linéaire"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_template_attribute_value__is_manual_price_extra
 msgid "Manual Price"
-msgstr "Prix manuel"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_template_attribute_value__manual_price_extra
 msgid "Manual Value Price Extra"
-msgstr "Valeur manuelle prix extra"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,help:mc_sale.field_product_template_attribute_value__manual_price_extra
 msgid ""
 "Manual extra price for the variant with this attribute value on sale price."
 msgstr ""
-"Prix extra entré manuellement pour la variante avec cette valeur d'attribut."
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_sale_order_line__fabrics_meterage_needed
 #: model:ir.model.fields,field_description:mc_sale.field_sale_product_configurator__fabrics_meterage_needed
 msgid "Meterage of fabrics"
-msgstr "Métrage de tissus"
+msgstr ""
 
 #. module: mc_sale
 #: model_terms:ir.ui.view,arch_db:mc_sale.contact
@@ -464,29 +443,29 @@ msgstr ""
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_sale_order__date_order
 msgid "Order Date"
-msgstr "Date de la commande"
+msgstr "Orderdatum"
 
 #. module: mc_sale
 #: model:mail.template,subject:mc_sale.mail_template_send_mail_confirmation_order
 msgid "Order confirmation (Ref ${object.name})"
-msgstr "Confirmation de commande (Réf ${object.name})"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields.selection,name:mc_sale.selection__product_attribute_value_percentage_price__type__percentage
 msgid "Percentage"
-msgstr "Pourcentage"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute_value__percentage_price_ids
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute_value_percentage_price__percentage_price
 msgid "Percentage Price"
-msgstr "Pourcentage (prix)"
+msgstr ""
 
 #. module: mc_sale
 #: model_terms:ir.ui.view,arch_db:mc_sale.product_attribute_value_percentage_price_view_tree
 #: model_terms:ir.ui.view,arch_db:mc_sale.product_attribute_value_view_form
 msgid "Percentage Prices"
-msgstr "Pourcentages (prix)"
+msgstr ""
 
 #. module: mc_sale
 #: model_terms:ir.ui.view,arch_db:mc_sale.contact
@@ -499,62 +478,60 @@ msgid ""
 "Pre-filled the linear length in the produt configurator with the linear "
 "length defined on the product form view."
 msgstr ""
-"Précharger la longueur linéaire dans le configurateur du produit avec la "
-"longueur linéaire définie dans le formulaire du produit."
 
 #. module: mc_sale
 #: model:ir.model.fields,help:mc_sale.field_sale_order_line__product_sale_price
 msgid "Price at which the product is sold to customers."
-msgstr "Prix auquel le produit est vendu aux clients."
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_product_product
 #: model:ir.model.fields,field_description:mc_sale.field_product_configurator_description_line__product_tmpl_id
 msgid "Product"
-msgstr "Produit"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_product_attribute
 #: model:ir.model.fields,field_description:mc_sale.field_product_configurator_description_line_value__attribute_id
 #: model:ir.model.fields.selection,name:mc_sale.selection__product_configurator_description_line_value__type__attribute
 msgid "Product Attribute"
-msgstr "Caractéristique de l'article"
+msgstr "Productkenmerk"
 
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_product_attribute_custom_value
 msgid "Product Attribute Custom Value"
-msgstr "Valeur caractéristique personnalisée du produit"
+msgstr "Product kenmerk aangepaste waarde"
 
 #. module: mc_sale
 #: model_terms:ir.ui.view,arch_db:mc_sale.product_attribute_value_view_form
 msgid "Product Attribute Lines"
-msgstr "Lignes d'attribut"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute_value_percentage_price__product_attribute_value_id
 msgid "Product Attribute Value"
-msgstr "Valeur d'attribut"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_product_category
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute_value_percentage_price__product_category_id
 msgid "Product Category"
-msgstr "Catégorie d'article"
+msgstr "Productcategorie"
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_sale_product_configurator__product_cost
 msgid "Product Cost"
-msgstr "Coût du produit"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_product_template
 msgid "Product Template"
-msgstr "Modèle d'article"
+msgstr "Productsjabloon"
 
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_product_template_attribute_value
 msgid "Product Template Attribute Value"
-msgstr "Valeur caratéristique du modèle produit"
+msgstr "Productsjabloon attribuut waard"
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_product__product_variant_seller_ids
@@ -567,8 +544,6 @@ msgstr ""
 #, python-format
 msgid "Product category and attribute value combination must be unique."
 msgstr ""
-"La combinaison de la catégorie du produit et la valeur d'attribut doit être "
-"unique."
 
 #. module: mc_sale
 #: model_terms:ir.ui.view,arch_db:mc_sale.res_config_settings_view_form
@@ -578,19 +553,19 @@ msgstr ""
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_purchase_order
 msgid "Purchase Order"
-msgstr "Commande fournisseur"
+msgstr "Aankooporder"
 
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_purchase_order_line
 msgid "Purchase Order Line"
-msgstr "Ligne de commande d'achat"
+msgstr "Aankooporderlijn"
 
 #. module: mc_sale
 #: model:ir.model.fields,help:mc_sale.field_product_product__linear_length
 #: model:ir.model.fields,help:mc_sale.field_product_template__linear_length
 #: model:ir.model.fields,help:mc_sale.field_sale_order_line__fabrics_meterage_needed
 msgid "Quantity of fabric required to upholster furniture"
-msgstr "Quantité de tissu requise pour recouvrir le meuble"
+msgstr ""
 
 #. module: mc_sale
 #: model_terms:ir.ui.view,arch_db:mc_sale.view_quotation_tree
@@ -600,7 +575,7 @@ msgstr ""
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_purchase_order__date_planned
 msgid "Receipt Date"
-msgstr "Date de réception"
+msgstr "Ontvangstdatum"
 
 #. module: mc_sale
 #: model_terms:ir.ui.view,arch_db:mc_sale.sale_order_form_view
@@ -621,27 +596,27 @@ msgstr ""
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_sale_product_configurator
 msgid "Sale Product Configurator"
-msgstr "Configurateur de produits pour la vente"
+msgstr "Verkoop productconfigurator"
 
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_sale_advance_payment_inv
 msgid "Sales Advance Payment Invoice"
-msgstr "Facture de paiement d'avance"
+msgstr "Verkoop vooruibetaling factuur"
 
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_sale_order
 msgid "Sales Order"
-msgstr "Bon de commande"
+msgstr "Verkooporder"
 
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_sale_order_line
 msgid "Sales Order Line"
-msgstr "Ligne du bon de commande"
+msgstr "Verkooporderregel"
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_stock_picking__scheduled_date
 msgid "Scheduled Date"
-msgstr "Date prévue"
+msgstr "Geplande datum"
 
 #. module: mc_sale
 #: model:ir.model.fields,help:mc_sale.field_stock_picking__scheduled_date
@@ -649,8 +624,9 @@ msgid ""
 "Scheduled time for the first part of the shipment to be processed. Setting "
 "manually a value here would set it as expected date for all the stock moves."
 msgstr ""
-"Heure prévue de la première partie à expédier. Préciser une date ici "
-"revient à spécifier la date prévue pour tous les mouvements de stocks."
+"De geplande tijd wanneer het eerste deel van levering wordt verwerkt. Het "
+"hier instellen van een handmatige waarde zal deze datum instellen als "
+"verwachte datum voor alle voorraadmutaties."
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_category__send_mail_order_confirmation
@@ -660,34 +636,34 @@ msgstr ""
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_configurator_description_line__sequence
 msgid "Sequence"
-msgstr "Séquence"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_delivery_carrier
 msgid "Shipping Methods"
-msgstr "Méthodes d'expédition"
+msgstr "Verzendwijzes"
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_account_move_line__short_name
 #: model:ir.model.fields,field_description:mc_sale.field_purchase_order_line__short_name
 #: model:ir.model.fields,field_description:mc_sale.field_sale_order_line__short_name
 msgid "Short Description"
-msgstr "Description (courte)"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute__display_short_description
 msgid "Show in Short Description"
-msgstr "Afficher la courte description"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_sale_product_configurator__standard_product_price
 msgid "Standard Product Price"
-msgstr "Prix standard du produit"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_sale_order_line__product_sale_price
 msgid "Standard Sale Price"
-msgstr "Prix de vente standard"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,help:mc_sale.field_product_product__hs_code
@@ -695,18 +671,18 @@ msgid ""
 "Standardized code for international shipping and goods declaration. At the "
 "moment, only used for the FedEx shipping provider."
 msgstr ""
-"Code normalisé pour l'expédition internationale et la déclaration de "
-"marchandises. Pour le moment, utilisé uniquement pour le transporteur FedEx."
+"Gestandaardiseerde code voor internationaal vervoer en goederen aangifte. "
+"Op dit moment alleen gebruikt voor de FedEx-verzendprovider."
 
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_stock_move
 msgid "Stock Move"
-msgstr "Stock déplacer"
+msgstr "Voorraadbeweging"
 
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_stock_rule
 msgid "Stock Rule"
-msgstr "Règle de stock minimum"
+msgstr "Voorraadregel"
 
 #. module: mc_sale
 #: model:ir.model.fields,help:mc_sale.field_product_product__is_tcl
@@ -717,7 +693,7 @@ msgstr ""
 #. module: mc_sale
 #: model:ir.model.fields.selection,name:mc_sale.selection__product_configurator_description_line_value__type__text
 msgid "Text"
-msgstr "Texte"
+msgstr ""
 
 #. module: mc_sale
 #: code:addons/mc_sale/models/product_attribute_custom_value.py:0
@@ -727,8 +703,6 @@ msgid ""
 "The custom value for the attribute '{}' should be a float like 2.25 or 2,25 "
 "(your input is {})."
 msgstr ""
-"La valeur  manuelle pour l'attribut '{}' devrait être un nombre à virgule "
-"du genre 2.25 ou 2,25 (vous avez entré est {})."
 
 #. module: mc_sale
 #: model:ir.model.fields,help:mc_sale.field_product_attribute__display_short_description
@@ -736,18 +710,16 @@ msgid ""
 "This information will be visible in short description of a sale order line "
 "or a purchase order line after product configuration"
 msgstr ""
-"Cette information sera visible dans la courte description d'une ligne de "
-"vente ou d'achat après la configuration du produit"
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_stock_picking__carrier_tracking_ref
 msgid "Tracking Reference"
-msgstr "Référence de suivi"
+msgstr "Referentie"
 
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_stock_picking
 msgid "Transfer"
-msgstr "Transfert"
+msgstr "Verplaatsing"
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_attribute_value_percentage_price__type
@@ -763,28 +735,28 @@ msgstr ""
 #. module: mc_sale
 #: model:ir.model.fields,help:mc_sale.field_product_template_attribute_value__is_manual_price_extra
 msgid "Used to prevent automatic computation of extra price"
-msgstr "Utilisé pour empêcher le calcul automatique du prix extra"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_template_attribute_value__price_extra
 msgid "Value Price Extra"
-msgstr "Lignes d'attributs de produit valides"
+msgstr "Waarde extra prijs"
 
 #. module: mc_sale
 #: model:ir.model.fields,help:mc_sale.field_product_attribute_value_percentage_price__percentage_price
 msgid "Value between 0 and 1 (e.g.: 0.5 = 50%)."
-msgstr "Valeur entre 0 et 1 (p. ex.: 0.5 = 50%)"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model,name:mc_sale.model_product_configurator_description_line_value
 msgid "Value of a Product Description Line"
-msgstr "Valeur d'une ligne descriptive"
+msgstr ""
 
 #. module: mc_sale
 #: model:ir.model.fields,field_description:mc_sale.field_product_configurator_description_line__value_ids
 #: model_terms:ir.ui.view,arch_db:mc_sale.product_attribute_value_view_form
 msgid "Values"
-msgstr "Valeurs"
+msgstr ""
 
 #. module: mc_sale
 #: model_terms:ir.ui.view,arch_db:mc_sale.product_product_easy_edit_form_view
@@ -805,9 +777,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:mc_sale.field_sale_order_line__price_unit
 #: model_terms:ir.ui.view,arch_db:mc_sale.sale_order_form_view
 msgid "Your Price"
-msgstr "Votre Prix"
+msgstr "Uw Prijs"
 
 #. module: mc_sale
 #: model_terms:ir.ui.view,arch_db:mc_sale.product_template_attribute_value_view_form
 msgid "manual price"
-msgstr "Prix manuel"
+msgstr ""

--- a/mc_sale/models/sale_order_line.py
+++ b/mc_sale/models/sale_order_line.py
@@ -15,7 +15,7 @@ class SaleOrderLine(models.Model):
     product_sale_price = fields.Float(related='product_template_id.list_price', string='Standard Sale Price')
     comment = fields.Text(string='Comment')
     short_name = fields.Text(string='Short Description')
-    price_unit = fields.Float(string='Customer Price')
+    price_unit = fields.Float(string='Your Price')
     route_id = fields.Many2one('stock.location.route', compute='_compute_route_id', store=True, readonly=False)
 
     @api.depends('order_id.carrier_id.route_id', 'product_id')

--- a/mc_sale/views/sale_order_views.xml
+++ b/mc_sale/views/sale_order_views.xml
@@ -100,10 +100,10 @@
                 <field name="carrier_id"/>
             </xpath>
             <xpath expr="//tree/field[@name='price_unit']" position="attributes">
-                <attribute name="string">Customer Price</attribute>
+                <attribute name="string">Your Price</attribute>
             </xpath>
             <xpath expr="//field[@name='order_line']/form/group/group/field[@name='price_unit']" position="attributes">
-                <attribute name="string">Customer Price</attribute>
+                <attribute name="string">Your Price</attribute>
             </xpath>
             <!--Useful for sending values to js-->
             <xpath expr="//tree/field[@name='product_template_id']" position="attributes">

--- a/mc_sale_layout/i18n/de.po
+++ b/mc_sale_layout/i18n/de.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-13 14:45+0000\n"
-"PO-Revision-Date: 2021-04-13 16:45+0200\n"
+"POT-Creation-Date: 2021-05-06 10:03+0000\n"
+"PO-Revision-Date: 2021-05-06 12:03+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
 "Language: de\n"
-"X-Generator: Poedit 2.4.2\n"
+"X-Generator: Poedit 2.4.3\n"
 
 #. module: mc_sale_layout
 #: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
@@ -99,11 +99,6 @@ msgstr "<span class=\"text-uppercase v-align-mid fs-6\">Preis laut Preisliste</s
 
 #. module: mc_sale_layout
 #: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
-msgid "<span class=\"text-uppercase v-align-mid fs-6\">Customer Price</span>"
-msgstr "<span class=\"text-uppercase v-align-mid fs-6\">Kundenpreis</span>"
-
-#. module: mc_sale_layout
-#: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
 msgid "<span class=\"text-uppercase v-align-mid fs-6\">Description</span>"
 msgstr "<span class=\"text-uppercase v-align-mid fs-6\">Artikelbeschreibung</span>"
 
@@ -136,6 +131,11 @@ msgstr "<span class=\"text-uppercase v-align-mid fs-6\">MwSt.</span>"
 #: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
 msgid "<span class=\"text-uppercase v-align-mid fs-6\">Total Price</span>"
 msgstr "<span class=\"text-uppercase v-align-mid fs-6\">Gesamtpreis</span>"
+
+#. module: mc_sale_layout
+#: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
+msgid "<span class=\"text-uppercase v-align-mid fs-6\">Your Price</span>"
+msgstr "<span class=\"text-uppercase v-align-mid fs-6\">Ihr Preis</span>"
 
 #. module: mc_sale_layout
 #: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
@@ -183,11 +183,32 @@ msgid "Bank account used by customer for payment"
 msgstr ""
 
 #. module: mc_sale_layout
+#: model_terms:ir.ui.view,arch_db:mc_sale_layout.print_sale_report_view_form
+msgid "Cancel"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__company_id
+msgid "Company"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: mc_sale_layout
 #: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
 msgid "Details"
 msgstr "Einzelheiten"
 
 #. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__display_name
 #: model:ir.model.fields,field_description:mc_sale_layout.field_report_mc_sale_layout_report_saleorder_downpayment__display_name
 #: model:ir.model.fields,field_description:mc_sale_layout.field_report_sale_report_saleorder__display_name
 msgid "Display Name"
@@ -204,15 +225,27 @@ msgid "IBAN:"
 msgstr ""
 
 #. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__id
 #: model:ir.model.fields,field_description:mc_sale_layout.field_report_mc_sale_layout_report_saleorder_downpayment__id
 #: model:ir.model.fields,field_description:mc_sale_layout.field_report_sale_report_saleorder__id
 msgid "ID"
 msgstr ""
 
 #. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report____last_update
 #: model:ir.model.fields,field_description:mc_sale_layout.field_report_mc_sale_layout_report_saleorder_downpayment____last_update
 #: model:ir.model.fields,field_description:mc_sale_layout.field_report_sale_report_saleorder____last_update
 msgid "Last Modified on"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__write_date
+msgid "Last Updated on"
 msgstr ""
 
 #. module: mc_sale_layout
@@ -226,14 +259,50 @@ msgid "Page: <span class=\"page\"/> / <span class=\"topage\"/>"
 msgstr "Seite: <span class=\"page\"/> / <span class=\"topage\"/>"
 
 #. module: mc_sale_layout
+#: model_terms:ir.ui.view,arch_db:mc_sale_layout.sale_order_form_view
+msgid "Print Report"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.actions.act_window,name:mc_sale_layout.print_sale_report_action
+#: model_terms:ir.ui.view,arch_db:mc_sale_layout.print_sale_report_view_form
+msgid "Print Sale Report"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.model,name:mc_sale_layout.model_print_sale_report
+msgid "Print Sale Report With Different Company Header/Footer"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model_terms:ir.ui.view,arch_db:mc_sale_layout.print_sale_report_view_form
+msgid "Print Selected Report"
+msgstr ""
+
+#. module: mc_sale_layout
 #: model:ir.actions.report,name:mc_sale_layout.action_report_saleorder_downpayment
 msgid "Quotation / Order with down payment"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__action_report_id
+msgid "Report"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__sale_order_id
+msgid "Sale Order"
 msgstr ""
 
 #. module: mc_sale_layout
 #: model:ir.model,name:mc_sale_layout.model_sale_order
 msgid "Sales Order"
 msgstr "Verkaufsauftrag "
+
+#. module: mc_sale_layout
+#: model_terms:ir.ui.view,arch_db:mc_sale_layout.print_sale_report_view_form
+msgid "Select a Printable Report"
+msgstr ""
 
 #. module: mc_sale_layout
 #: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
@@ -303,4 +372,10 @@ msgstr ""
 #. module: mc_sale_layout
 #: model:ir.model,name:mc_sale_layout.model_report_sale_report_saleorder
 msgid "report.sale.report_saleorder"
+msgstr ""
+
+#. module: mc_sale_layout
+#: code:addons/mc_sale_layout/wizard/print_sale_report.py:0
+#, python-format
+msgid "{} has been generated with {} header/footer."
 msgstr ""

--- a/mc_sale_layout/i18n/fr_BE.po
+++ b/mc_sale_layout/i18n/fr_BE.po
@@ -6,16 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-13 14:44+0000\n"
-"PO-Revision-Date: 2021-04-13 16:44+0200\n"
+"POT-Creation-Date: 2021-05-06 10:02+0000\n"
+"PO-Revision-Date: 2021-05-06 12:03+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
-"Language: fr\n"
-"X-Generator: Poedit 2.4.2\n"
+"Language: fr_BE\n"
+"X-Generator: Poedit 2.4.3\n"
 
 #. module: mc_sale_layout
 #: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
@@ -102,11 +102,6 @@ msgstr "<span class=\"text-uppercase v-align-mid fs-7\">Prix Tarif</span>"
 
 #. module: mc_sale_layout
 #: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
-msgid "<span class=\"text-uppercase v-align-mid fs-6\">Customer Price</span>"
-msgstr "<span class=\"text-uppercase v-align-mid fs-7\">Prix Client</span>"
-
-#. module: mc_sale_layout
-#: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
 msgid "<span class=\"text-uppercase v-align-mid fs-6\">Description</span>"
 msgstr ""
 
@@ -139,6 +134,11 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
 msgid "<span class=\"text-uppercase v-align-mid fs-6\">Total Price</span>"
 msgstr "<span class=\"text-uppercase v-align-mid fs-7\">Montant TVAC</span>"
+
+#. module: mc_sale_layout
+#: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
+msgid "<span class=\"text-uppercase v-align-mid fs-6\">Your Price</span>"
+msgstr "<span class=\"text-uppercase v-align-mid fs-7\">Votre Prix</span>"
 
 #. module: mc_sale_layout
 #: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
@@ -186,11 +186,32 @@ msgid "Bank account used by customer for payment"
 msgstr "Compte bancaire utilisé par le client pour les paiements"
 
 #. module: mc_sale_layout
+#: model_terms:ir.ui.view,arch_db:mc_sale_layout.print_sale_report_view_form
+msgid "Cancel"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__company_id
+msgid "Company"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: mc_sale_layout
 #: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
 msgid "Details"
 msgstr "Détails"
 
 #. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__display_name
 #: model:ir.model.fields,field_description:mc_sale_layout.field_report_mc_sale_layout_report_saleorder_downpayment__display_name
 #: model:ir.model.fields,field_description:mc_sale_layout.field_report_sale_report_saleorder__display_name
 msgid "Display Name"
@@ -207,16 +228,28 @@ msgid "IBAN:"
 msgstr ""
 
 #. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__id
 #: model:ir.model.fields,field_description:mc_sale_layout.field_report_mc_sale_layout_report_saleorder_downpayment__id
 #: model:ir.model.fields,field_description:mc_sale_layout.field_report_sale_report_saleorder__id
 msgid "ID"
 msgstr ""
 
 #. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report____last_update
 #: model:ir.model.fields,field_description:mc_sale_layout.field_report_mc_sale_layout_report_saleorder_downpayment____last_update
 #: model:ir.model.fields,field_description:mc_sale_layout.field_report_sale_report_saleorder____last_update
 msgid "Last Modified on"
 msgstr "Dernière modification le"
+
+#. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__write_date
+msgid "Last Updated on"
+msgstr ""
 
 #. module: mc_sale_layout
 #: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_external_layout
@@ -229,14 +262,50 @@ msgid "Page: <span class=\"page\"/> / <span class=\"topage\"/>"
 msgstr ""
 
 #. module: mc_sale_layout
+#: model_terms:ir.ui.view,arch_db:mc_sale_layout.sale_order_form_view
+msgid "Print Report"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.actions.act_window,name:mc_sale_layout.print_sale_report_action
+#: model_terms:ir.ui.view,arch_db:mc_sale_layout.print_sale_report_view_form
+msgid "Print Sale Report"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.model,name:mc_sale_layout.model_print_sale_report
+msgid "Print Sale Report With Different Company Header/Footer"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model_terms:ir.ui.view,arch_db:mc_sale_layout.print_sale_report_view_form
+msgid "Print Selected Report"
+msgstr ""
+
+#. module: mc_sale_layout
 #: model:ir.actions.report,name:mc_sale_layout.action_report_saleorder_downpayment
 msgid "Quotation / Order with down payment"
 msgstr "Devis / Commande avec acompte"
 
 #. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__action_report_id
+msgid "Report"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__sale_order_id
+msgid "Sale Order"
+msgstr ""
+
+#. module: mc_sale_layout
 #: model:ir.model,name:mc_sale_layout.model_sale_order
 msgid "Sales Order"
 msgstr "Bon de commande"
+
+#. module: mc_sale_layout
+#: model_terms:ir.ui.view,arch_db:mc_sale_layout.print_sale_report_view_form
+msgid "Select a Printable Report"
+msgstr ""
 
 #. module: mc_sale_layout
 #: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
@@ -306,4 +375,10 @@ msgstr ""
 #. module: mc_sale_layout
 #: model:ir.model,name:mc_sale_layout.model_report_sale_report_saleorder
 msgid "report.sale.report_saleorder"
+msgstr ""
+
+#. module: mc_sale_layout
+#: code:addons/mc_sale_layout/wizard/print_sale_report.py:0
+#, python-format
+msgid "{} has been generated with {} header/footer."
 msgstr ""

--- a/mc_sale_layout/i18n/nl_BE.po
+++ b/mc_sale_layout/i18n/nl_BE.po
@@ -6,16 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-13 14:42+0000\n"
-"PO-Revision-Date: 2021-04-13 16:43+0200\n"
+"POT-Creation-Date: 2021-05-06 10:02+0000\n"
+"PO-Revision-Date: 2021-05-06 12:04+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
-"Language: nl\n"
-"X-Generator: Poedit 2.4.2\n"
+"Language: nl_BE\n"
+"X-Generator: Poedit 2.4.3\n"
 
 #. module: mc_sale_layout
 #: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
@@ -108,11 +108,6 @@ msgstr "<span class=\"text-uppercase v-align-mid fs-6\">Basis Prijs</span>"
 
 #. module: mc_sale_layout
 #: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
-msgid "<span class=\"text-uppercase v-align-mid fs-6\">Customer Price</span>"
-msgstr "<span class=\"text-uppercase v-align-mid fs-6\">Prijs Klant</span>"
-
-#. module: mc_sale_layout
-#: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
 msgid "<span class=\"text-uppercase v-align-mid fs-6\">Description</span>"
 msgstr "<span class=\"text-uppercase v-align-mid fs-6\">Omschrijving</span>"
 
@@ -148,6 +143,11 @@ msgstr "<span class=\"text-uppercase v-align-mid fs-6\">Totale Prijs</span>"
 
 #. module: mc_sale_layout
 #: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
+msgid "<span class=\"text-uppercase v-align-mid fs-6\">Your Price</span>"
+msgstr "<span class=\"text-uppercase v-align-mid fs-6\">Uw Prijs</span>"
+
+#. module: mc_sale_layout
+#: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
 msgid "<span style=\"font-size: 1.7rem;\">Lending Confirmation</span>"
 msgstr "<span style=\"font-size: 1.7rem;\">Orderbevest. op zicht</span>"
 
@@ -159,7 +159,7 @@ msgstr "<span style=\"font-size: 1.7rem;\">Orderbevest. op zicht</span>"
 #. module: mc_sale_layout
 #: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
 msgid "<span>Order</span>"
-msgstr ""
+msgstr "<span>Bevestiging</span>"
 
 #. module: mc_sale_layout
 #: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
@@ -192,11 +192,32 @@ msgid "Bank account used by customer for payment"
 msgstr ""
 
 #. module: mc_sale_layout
+#: model_terms:ir.ui.view,arch_db:mc_sale_layout.print_sale_report_view_form
+msgid "Cancel"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__company_id
+msgid "Company"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: mc_sale_layout
 #: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
 msgid "Details"
 msgstr ""
 
 #. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__display_name
 #: model:ir.model.fields,field_description:mc_sale_layout.field_report_mc_sale_layout_report_saleorder_downpayment__display_name
 #: model:ir.model.fields,field_description:mc_sale_layout.field_report_sale_report_saleorder__display_name
 msgid "Display Name"
@@ -213,15 +234,27 @@ msgid "IBAN:"
 msgstr ""
 
 #. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__id
 #: model:ir.model.fields,field_description:mc_sale_layout.field_report_mc_sale_layout_report_saleorder_downpayment__id
 #: model:ir.model.fields,field_description:mc_sale_layout.field_report_sale_report_saleorder__id
 msgid "ID"
 msgstr ""
 
 #. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report____last_update
 #: model:ir.model.fields,field_description:mc_sale_layout.field_report_mc_sale_layout_report_saleorder_downpayment____last_update
 #: model:ir.model.fields,field_description:mc_sale_layout.field_report_sale_report_saleorder____last_update
 msgid "Last Modified on"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__write_date
+msgid "Last Updated on"
 msgstr ""
 
 #. module: mc_sale_layout
@@ -235,14 +268,50 @@ msgid "Page: <span class=\"page\"/> / <span class=\"topage\"/>"
 msgstr "Pagina: <span class=\"page\"/> / <span class=\"topage\"/>"
 
 #. module: mc_sale_layout
+#: model_terms:ir.ui.view,arch_db:mc_sale_layout.sale_order_form_view
+msgid "Print Report"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.actions.act_window,name:mc_sale_layout.print_sale_report_action
+#: model_terms:ir.ui.view,arch_db:mc_sale_layout.print_sale_report_view_form
+msgid "Print Sale Report"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.model,name:mc_sale_layout.model_print_sale_report
+msgid "Print Sale Report With Different Company Header/Footer"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model_terms:ir.ui.view,arch_db:mc_sale_layout.print_sale_report_view_form
+msgid "Print Selected Report"
+msgstr ""
+
+#. module: mc_sale_layout
 #: model:ir.actions.report,name:mc_sale_layout.action_report_saleorder_downpayment
 msgid "Quotation / Order with down payment"
 msgstr "Offerte / Bestelling met aanbetaling"
 
 #. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__action_report_id
+msgid "Report"
+msgstr ""
+
+#. module: mc_sale_layout
+#: model:ir.model.fields,field_description:mc_sale_layout.field_print_sale_report__sale_order_id
+msgid "Sale Order"
+msgstr ""
+
+#. module: mc_sale_layout
 #: model:ir.model,name:mc_sale_layout.model_sale_order
 msgid "Sales Order"
 msgstr "Verkooporder"
+
+#. module: mc_sale_layout
+#: model_terms:ir.ui.view,arch_db:mc_sale_layout.print_sale_report_view_form
+msgid "Select a Printable Report"
+msgstr ""
 
 #. module: mc_sale_layout
 #: model_terms:ir.ui.view,arch_db:mc_sale_layout.mc_report_saleorder_document
@@ -317,4 +386,10 @@ msgstr ""
 #. module: mc_sale_layout
 #: model:ir.model,name:mc_sale_layout.model_report_sale_report_saleorder
 msgid "report.sale.report_saleorder"
+msgstr ""
+
+#. module: mc_sale_layout
+#: code:addons/mc_sale_layout/wizard/print_sale_report.py:0
+#, python-format
+msgid "{} has been generated with {} header/footer."
 msgstr ""

--- a/mc_sale_layout/report/sale_order_templates.xml
+++ b/mc_sale_layout/report/sale_order_templates.xml
@@ -140,7 +140,7 @@
                               <span class="text-uppercase v-align-mid fs-6">Base Price</span>
                             </th>
                             <th name="th_priceunit" class="text-center" style="width: 11%">
-                              <span class="text-uppercase v-align-mid fs-6">Customer Price</span>
+                              <span class="text-uppercase v-align-mid fs-6">Your Price</span>
                             </th>
                             <th name="th_discount" t-if="display_discount" class="text-center" groups="product.group_discount_per_so_line">
                                 <span class="text-uppercase v-align-mid fs-6">Disc.%</span>
@@ -157,7 +157,7 @@
                     <tbody class="sale_tbody">
 
                         <t t-set="current_subtotal" t-value="0"/>
-                        <t t-set="order_lines_without_deposit" t-value="doc.order_line.filtered(lambda line: not line.is_downpayment)"/>
+                        <t t-set="order_lines_without_deposit" t-value="doc.order_line.filtered(lambda line: not line.is_downpayment and line.product_uom_qty > 0)"/>
                         <!-- do not display downpayments -->
                         <t t-foreach="order_lines_without_deposit" t-as="line">
 


### PR DESCRIPTION
Dans les pdf imprimable depuis le SO il ne faut pas reprendre les lignes qui ont un quantité demandé = 0 (product_uom_qty = 0).

Change le libellé prix client en "votre prix" (price_unit). Dans backend et pdf.


NL : Uw Prijs

ENG : Your Price

ALL : Ihr Preis